### PR TITLE
SyncPubsub: In hashIBLT, just use the name component value

### DIFF
--- a/syncps/syncps.hpp
+++ b/syncps/syncps.hpp
@@ -577,9 +577,9 @@ class SyncPubsub
 
     uint32_t hashIBLT(const Name& n) const
     {
-        const auto& b = n[-1].wireEncode();
+        const auto& b = n[-1];
         return murmurHash3(N_HASHCHECK,
-                           std::vector<uint8_t>(b.wire(), b.wire() + b.size()));
+                           std::vector<uint8_t>(b.value_begin(), b.value_end()));
     }
 
   private:


### PR DESCRIPTION
The name component has the encoded IBLT. Currently, to get its hash, the name component is encoded as a TLV, where the value is just the encoded IBLT byte array. There's no need to take the time to create a new buffer which just adds the TLV type and length bytes. The NDN-IND branch just uses the component value. This pull request makes it compatible.